### PR TITLE
go runners are at this feature exclusive to a machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,7 @@ RUN cd /home/${USER} && \
     mkdir -p /home/${USER}/go && \
     wget -O /tmp/go.tgz https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar xzf /tmp/go.tgz && \
-    rm /tmp/go.tgz && \
-    wget -O /home/${USER}/go/bin/jfrog "https://bintray.com/jfrog/jfrog-cli-go/download_file?file_path=1.11.2%2Fjfrog-cli-linux-386%2Fjfrog" && \
-    chmod +x /home/${USER}/go/bin/jfrog
+    rm /tmp/go.tgz
 
 
 ENV PATH=$PATH:/home/${USER}/go/bin
@@ -64,9 +62,3 @@ VOLUME /project
 WORKDIR /project/src/github.com/SentientTechnologies/studio-go-runner
 
 CMD /bin/bash -C ./build.sh
-
-#FROM ubuntu:16.04
-
-#WORKDIR /root/
-#COPY --from=builder /project/bin/. .
-#CMD ["ls"]

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -170,6 +170,11 @@ func main() {
 		}
 	}
 
+	if _, err = runner.NewExclusive("studio-go-runner", quitC); err != nil {
+		logger.Error(fmt.Sprintf("An instance of this process is already running %s", err.Error()))
+		fatalErr = true
+	}
+
 	// Now check for any fatal errors before allowing the system to continue.  This allows
 	// all errors that could have ocuured as a result of incorrect options to be flushed
 	// out rather than having a frustrating single failure at a time loop for users

--- a/singleton.go
+++ b/singleton.go
@@ -1,0 +1,47 @@
+package runner
+
+// This file contains the implementation of code that checks to ensure
+// that the local machine only has one entity accessing a named resource.
+// This allows callers of this code to create and test for exclusive
+// access to resources, or to check that only one instance of a
+// process is running.
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/go-stack/stack"
+	"github.com/karlmutch/errors"
+)
+
+type Exclusive struct {
+	Name     string
+	ReleaseC chan bool
+	listen   net.Listener
+}
+
+func NewExclusive(name string, quitC chan bool) (excl *Exclusive, err errors.Error) {
+
+	excl = &Exclusive{
+		Name:     name,
+		ReleaseC: quitC,
+	}
+
+	// Construct an abstract name socket that allows the name to be recycled between process
+	// restarts without needing to unlink etc. For more information please see
+	// https://gavv.github.io/blog/unix-socket-reuse/, and
+	// http://man7.org/linux/man-pages/man7/unix.7.html
+	sockName := "@/tmp/"
+	sockName += name
+
+	errGo := fmt.Errorf("")
+	excl.listen, errGo = net.Listen("unix", sockName)
+	if errGo != nil {
+		return nil, errors.Wrap(errGo).With("stack", stack.Trace().TrimRuntime())
+	}
+	go func() {
+		go excl.listen.Accept()
+		<-excl.ReleaseC
+	}()
+	return excl, nil
+}


### PR DESCRIPTION
In preparation for resource tenancy and a means by which resources can be shared between multiple runners we first implement a feature to stop multiple runners from being present on a machine